### PR TITLE
Fix action schedule, increase timeout and pin version

### DIFF
--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@v1.5.1
         with:
           args: --verbose --no-progress './**/*.md' './**/*.html' --timeout 60
           fail: true

--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1
         with:
+          args: --verbose --no-progress './**/*.md' './**/*.html' --timeout 60
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "* * * * 0" # run every Sunday
+    - cron: "00 1 * * 0" # run at 01:00 on Sundays
 
 jobs:
   linkChecker:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1
+        with:
+          args: --verbose --no-progress './**/*.md' './**/*.html' --timeout 60
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@v1.5.1
         with:
           args: --verbose --no-progress './**/*.md' './**/*.html' --timeout 60
         env:


### PR DESCRIPTION
Given that the workflow test passed too successfully, this PR fixes this and makes it run only once on Sundays.

Sorry for the bunch of issues 😅

This PR also increases the timeout to 60 seconds to prevent false positives, as seen in today's issues.

And the last, it pins the container version, as lychee-action authors [recommend](https://github.com/lycheeverse/lychee-action#security-and-updates).

Ideally, this should be 3 separate pull requests, but the changes are so small, I guess it's ok 😀